### PR TITLE
(Fix) - Return default value on getNetworkNodes

### DIFF
--- a/src/modules/context/getNetworkNodes.ts
+++ b/src/modules/context/getNetworkNodes.ts
@@ -26,6 +26,9 @@ export const getNetworkNodes = async ({
 }) => {
   const base = FIXED_NODE_ENDPOINT[bridge][mode][0];
   const url = base + '/api/v1/peers';
-  const peers = await fetcher<SkybridgePeer[]>(url);
-  return peers;
+  try {
+    return await fetcher<SkybridgePeer[]>(url);
+  } catch (error) {
+    return [];
+  }
 };


### PR DESCRIPTION
## Description
- Now the method `getNetworkNodes` has a try catch to avoid throwing errors an returns a fallback